### PR TITLE
Save tokens to cookie

### DIFF
--- a/src/main/java/com/omwan/latestadditions/controller/AuthController.java
+++ b/src/main/java/com/omwan/latestadditions/controller/AuthController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Controller for authentication-related services.
  */
@@ -18,12 +20,13 @@ public class AuthController {
     private AuthService authService;
 
     @RequestMapping(method = RequestMethod.GET, value = "")
-    public void authorize() {
-        authService.authorize();
+    public void authorize(HttpServletResponse response) {
+        authService.authorize(response);
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "/tokens")
-    public void setToken(@RequestParam(name = "code") String token) {
-        authService.setToken(token);
+    public void setToken(@RequestParam(name = "code") String token,
+                         HttpServletResponse response) {
+        authService.setToken(token, response);
     }
 }

--- a/src/main/java/com/omwan/latestadditions/service/AuthService.java
+++ b/src/main/java/com/omwan/latestadditions/service/AuthService.java
@@ -1,11 +1,13 @@
 package com.omwan.latestadditions.service;
 
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Services relating to authentication.
  */
 public interface AuthService {
 
-    void authorize();
+    void authorize(HttpServletResponse response);
 
-    void setToken(String token);
+    void setToken(String token, HttpServletResponse response);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,5 @@ spring.data.mongodb.uri=${MONGODB_URI}
 spotify.client=${SPOTIFY_CLIENT}
 spotify.client.secret=${SPOTIFY_CLIENT_SECRET}
 spotify.redirect.uri=${SPOTIFY_REDIRECT_URI}
+
+cookie.domain=${COOKIE_DOMAIN}


### PR DESCRIPTION
Fixing issue where tokens were originally saved as session attributes, meaning they would be lost upon dyno restart on heroku, requiring users to go through authentication step every time they used the application after the dynos had gone to sleep. 

Unit tests updated for new logic.