### PR TITLE
Refresh token logic moved from session to cookie, user ID in cookie

### DIFF
--- a/src/main/java/com/omwan/latestadditions/component/CookieUtils.java
+++ b/src/main/java/com/omwan/latestadditions/component/CookieUtils.java
@@ -1,0 +1,49 @@
+package com.omwan.latestadditions.component;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Utils class to handle functionality relating to cookies.
+ */
+@Component
+public class CookieUtils {
+
+    @Value("${cookie.domain}")
+    private String cookieDomain;
+
+    /**
+     * Create a cookie with the given name and value and set the domain and related
+     * attributes as needed.
+     *
+     * @param name  name of cookie
+     * @param value value of cookie
+     * @return cookie instance
+     */
+    public Cookie buildCookie(String name, String value) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setDomain(cookieDomain);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        return cookie;
+    }
+
+    /**
+     * Retrieve the value of the given cookie name, or throw an appropriate exception
+     * if the cookie does not exist.
+     *
+     * @param cookieName name of cookie to retrieve value for
+     * @return value of cookie
+     */
+    public String getCookieValue(HttpServletRequest request, String cookieName) {
+        Cookie cookie = WebUtils.getCookie(request, cookieName);
+        if (cookie == null) {
+            throw new RuntimeException("Cookie " + cookieName + " does not exist");
+        }
+        return cookie.getValue();
+    }
+}

--- a/src/main/java/com/omwan/latestadditions/service/AuthServiceImpl.java
+++ b/src/main/java/com/omwan/latestadditions/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.omwan.latestadditions.service;
 
+import com.omwan.latestadditions.component.CookieUtils;
 import com.omwan.latestadditions.component.SpotifyApiComponent;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.SpotifyWebApiException;
@@ -7,10 +8,8 @@ import com.wrapper.spotify.model_objects.credentials.AuthorizationCodeCredential
 import com.wrapper.spotify.requests.authorization.authorization_code.AuthorizationCodeRequest;
 import com.wrapper.spotify.requests.authorization.authorization_code.AuthorizationCodeUriRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
@@ -26,8 +25,8 @@ public class AuthServiceImpl implements AuthService {
     @Autowired
     private SpotifyApiComponent spotifyApiComponent;
 
-    @Value("${cookie.domain}")
-    private String cookieDomain;
+    @Autowired
+    private CookieUtils cookieUtils;
 
     /**
      * Make authorization request for API usage.
@@ -61,20 +60,14 @@ public class AuthServiceImpl implements AuthService {
                 .build();
         try {
             AuthorizationCodeCredentials authorizationCodeCredentials = authorizationCodeRequest.execute();
-            response.addCookie(buildCookie("ACCESS_TOKEN", authorizationCodeCredentials.getAccessToken()));
-            response.addCookie(buildCookie("REFRESH_TOKEN", authorizationCodeCredentials.getRefreshToken()));
+            response.addCookie(cookieUtils.buildCookie("ACCESS_TOKEN",
+                    authorizationCodeCredentials.getAccessToken()));
+            response.addCookie(cookieUtils.buildCookie("REFRESH_TOKEN",
+                    authorizationCodeCredentials.getRefreshToken()));
             handleRedirect(response, "/", "Could not redirect to application main page");
         } catch (IOException | SpotifyWebApiException e) {
             throw new RuntimeException("Could not retrieve auth code credentials", e);
         }
-    }
-
-    private Cookie buildCookie(String name, String value) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setDomain(cookieDomain);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        return cookie;
     }
 
     /**

--- a/src/test/java/com/omwan/latestadditions/component/CookieUtilsTest.java
+++ b/src/test/java/com/omwan/latestadditions/component/CookieUtilsTest.java
@@ -1,0 +1,84 @@
+package com.omwan.latestadditions.component;
+
+import mockit.Deencapsulation;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Tested;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.util.WebUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for utils relating to cookies.
+ */
+public class CookieUtilsTest {
+
+    private final static String COOKIE_DOMAIN = "domain";
+
+    @Tested
+    private CookieUtils cookieUtils;
+
+    @Before
+    public void setup() {
+        cookieUtils = new CookieUtils();
+        Deencapsulation.setField(cookieUtils, "cookieDomain", COOKIE_DOMAIN);
+    }
+
+    /**
+     * Assert that cookies are built with the given parameters and have the correct
+     * domain set.
+     */
+    @Test
+    public void testBuildCookie() throws Exception {
+        Cookie expected = new Cookie("name", "value");
+        expected.setDomain(COOKIE_DOMAIN);
+
+        Cookie actual = cookieUtils.buildCookie("name", "value");
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getValue(), actual.getValue());
+        assertEquals(expected.getDomain(), actual.getDomain());
+    }
+
+    /**
+     * Assert that the value of a cookie with a given name can be retrieved.
+     */
+    @Test
+    public void testGetCookieValue() throws Exception {
+        HttpServletRequest request = new MockHttpServletRequest();
+        String expectedValue = "value";
+
+        new MockUp<WebUtils>() {
+            @Mock
+            public Cookie getCookie(HttpServletRequest request, String name) {
+                return new Cookie(name, expectedValue);
+            }
+        };
+
+        String actualValue = cookieUtils.getCookieValue(request, "name");
+        assertEquals(expectedValue, actualValue);
+    }
+
+    /**
+     * Assert that if the getCookieValue method is called with a name of a cookie
+     * that does not exist, the appropriate exception is thrown.
+     */
+    @Test(expected = RuntimeException.class)
+    public void testGetCookieValueNullCookie() throws Exception {
+        HttpServletRequest request = new MockHttpServletRequest();
+
+        new MockUp<WebUtils>() {
+            @Mock
+            public Cookie getCookie(HttpServletRequest request, String name) {
+                return null;
+            }
+        };
+
+        cookieUtils.getCookieValue(request, "name");
+    }
+}

--- a/src/test/java/com/omwan/latestadditions/component/SpotifyApiComponentTest.java
+++ b/src/test/java/com/omwan/latestadditions/component/SpotifyApiComponentTest.java
@@ -9,10 +9,10 @@ import mockit.MockUp;
 import mockit.Tested;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.web.util.WebUtils;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import static org.junit.Assert.assertEquals;
@@ -22,6 +22,10 @@ import static org.junit.Assert.assertEquals;
  */
 public class SpotifyApiComponentTest {
 
+    private final static String SPOTIFY_CLIENT = "client";
+    private final static String SPOTIFY_CLIENT_SECRET = "secret";
+    private final static String SPOTIFY_REDIRECT_URI = "redirect";
+
     @Tested
     private SpotifyApiComponent spotifyApiComponent;
 
@@ -29,11 +33,13 @@ public class SpotifyApiComponentTest {
     private HttpServletRequest request;
 
     @Injectable
+    private HttpServletResponse response;
+
+    @Injectable
     private HttpSession httpSession;
 
-    private final static String SPOTIFY_CLIENT = "client";
-    private final static String SPOTIFY_CLIENT_SECRET = "secret";
-    private final static String SPOTIFY_REDIRECT_URI = "redirect";
+    @Injectable
+    private CookieUtils cookieUtils;
 
     @Before
     public void setup() {
@@ -57,23 +63,20 @@ public class SpotifyApiComponentTest {
 
     /**
      * Assert that the access and refresh tokens can be successfully retrieved
-     * from the session attributes and set in a spotify api instance.
+     * from the cookies and set in a spotify api instance.
      */
     @Test
     public void testGetApiWithTokens() {
         final String expectedAccessToken = "access token";
         final String expectedRefreshToken = "refresh token";
 
-        new MockUp<WebUtils>() {
-            @Mock
-            public Cookie getCookie(HttpServletRequest request, String cookieName) {
-                if (cookieName.equals("ACCESS_TOKEN")) {
-                    return new Cookie(cookieName, expectedAccessToken);
-                } else {
-                    return new Cookie(cookieName, expectedRefreshToken);
-                }
-            }
-        };
+        new Expectations() {{
+            cookieUtils.getCookieValue(request, "ACCESS_TOKEN");
+            returns(expectedAccessToken);
+
+            cookieUtils.getCookieValue(request, "REFRESH_TOKEN");
+            returns(expectedRefreshToken);
+        }};
 
         SpotifyApi actual = spotifyApiComponent.getApiWithTokens();
         assertEquals(actual.getClientId(), SPOTIFY_CLIENT);
@@ -84,55 +87,14 @@ public class SpotifyApiComponentTest {
     }
 
     /**
-     * Assert that if the access and refresh tokens cannot be retrieved from the
-     * session attributes, the appropriate exception is thrown.
-     */
-    @Test(expected = RuntimeException.class)
-    public void testGetApiWithTokensMissingAttributes() {
-        new MockUp<WebUtils>() {
-            @Mock
-            public Cookie getCookie(HttpServletRequest request, String cookieName) {
-                return null;
-            }
-        };
-
-        spotifyApiComponent.getApiWithTokens();
-    }
-
-    /**
-     * Assert that the current user's ID can be retrieved from the spotify API
-     * and set as a session attribute.
+     * Assert that the current user's ID can be retrieved from the cookie.
      */
     @Test
-    public void testGetCurrentUserIdNoSessionAttribute() {
-        final String expectedUserId = "user ID";
-        new MockUp<SpotifyApiComponent>() {
-            @Mock
-            public String getCurrentUserIdFromApi() {
-                return expectedUserId;
-            }
-        };
-
-        new Expectations() {{
-            httpSession.getAttribute("USER_ID");
-            returns(null);
-
-            httpSession.setAttribute("USER_ID", expectedUserId);
-        }};
-
-        String actual = spotifyApiComponent.getCurrentUserId();
-        assertEquals(actual, expectedUserId);
-    }
-
-    /**
-     * Assert that the current user's ID can be retrieved from the session attributes.
-     */
-    @Test
-    public void testGetCurrentUserIdWithSessionAttribute() {
+    public void testGetCurrentUserIdWithCookie() {
         final String expectedUserId = "user ID";
 
         new Expectations() {{
-            httpSession.getAttribute("USER_ID");
+            cookieUtils.getCookieValue(request, "USER_ID");
             returns(expectedUserId);
         }};
 
@@ -141,17 +103,33 @@ public class SpotifyApiComponentTest {
     }
 
     /**
-     * Mock a session attribute with the given value.
-     *
-     * @param value value of the session attribute to mock
-     * @return mocked session attribute object
+     * Assert that if the current user ID has not yet been set as a cookie,
+     * it can be retrieved from the API and then is set as a cookie.
      */
-    private MockUp<Object> mockSessionAttribute(String value) {
-        return new MockUp<Object>() {
+    @Test
+    public void testGetCurrentUserIdWithoutCookie() throws Exception {
+        final String expectedUserId = "user ID";
+
+        new MockUp<SpotifyApiComponent>() {
             @Mock
-            public String toString() {
-                return value;
+            public String getCurrentUserIdFromApi() {
+                return expectedUserId;
             }
         };
+
+        final Cookie userIdCookie = new Cookie("USER_ID", expectedUserId);
+
+        new Expectations() {{
+            cookieUtils.getCookieValue(request, "USER_ID");
+            result = new RuntimeException();
+
+            cookieUtils.buildCookie("USER_ID", expectedUserId);
+            returns(userIdCookie);
+
+            response.addCookie(userIdCookie);
+        }};
+
+        String actual = spotifyApiComponent.getCurrentUserId();
+        assertEquals(actual, expectedUserId);
     }
 }

--- a/src/test/java/com/omwan/latestadditions/service/SavedPlaylistServiceImplTest.java
+++ b/src/test/java/com/omwan/latestadditions/service/SavedPlaylistServiceImplTest.java
@@ -73,7 +73,7 @@ public class SavedPlaylistServiceImplTest {
     }
 
     /**
-     * Assert that if the session attributes containing the access tokens are
+     * Assert that if the cookies containing the access tokens are
      * not set, the function returns an empty response.
      */
     @Test


### PR DESCRIPTION
Updating refreshToken and getCurrentUserId methods in SpotifyApiComponent to save attributes to cookies rather than session attributes in accordance with previous PR changes.

Created CookieUtils class to manage repeated functionality relating to cookies.

Updated + created new unit tests for new logic.